### PR TITLE
allow the created role to use the kms key created by this module

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -54,6 +54,14 @@ data "aws_iam_policy_document" "policy_doc" {
     ]
     resources = [aws_dynamodb_table.dynamodb_table.arn]
   }
+
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = [aws_kms_key.kms_key.arn]
+  }
 }
 
 resource "aws_iam_policy" "iam_policy" {


### PR DESCRIPTION
Hi,

Not sure why this wasn't picked up before. The IAM role created needs permissions to invoke KMS actions, even if the ACL of the KMS key created allows to be called by it.

Thanks for the good stuff in the book!